### PR TITLE
signed_urlのキャッシュ期間を3分から3時間に更新

### DIFF
--- a/config/initializers/extensions/active_storage.rb
+++ b/config/initializers/extensions/active_storage.rb
@@ -1,0 +1,8 @@
+module ActiveStorageBlobControllerExtension
+  def show
+    expires_in 3.hours, public: true
+    redirect_to @blob.service_url(disposition: params[:disposition], expires_in: 3.hours)
+  end
+end
+
+ActiveStorage::BlobsController.prepend(ActiveStorageBlobControllerExtension)

--- a/config/initializers/extensions/googlecloudstorage.rb
+++ b/config/initializers/extensions/googlecloudstorage.rb
@@ -1,8 +1,24 @@
 require "google/cloud/storage"
 
 module GCSFileSignerExtension
+  # Remove 'storage.googleapis.com' from url
   def ext_url
     "https:/#{ext_path}"
+  end
+
+  # Longer expire time (4 hours)
+  def signed_url(options)
+    options[:expires] = 14_400
+
+    options = apply_option_defaults options
+
+    i = determine_issuer options
+    s = determine_signing_key options
+
+    raise SignedUrlUnavailable unless i && s
+
+    sig = generate_signature s, signature_str(options)
+    generate_signed_url i, sig, options[:expires], options[:query]
   end
 end
 


### PR DESCRIPTION
signed_urlのキャッシュ時間が短すぎるためにほとんどキャッシュされていなかった問題
→キャッシュ時間を3時間にすることで改善