### PR TITLE
ログアウト時に発生する500エラーを修正

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -81,10 +81,12 @@ class UsersController < ApplicationController
   end
 
   def logout
-    # cookieを削除すればログアウト処理に
-    logout_user(current_user)
-    flash[:success] = 'ログアウトしました'
-    redirect_back(fallback_location: root_path)
+    if logged_in?
+      # cookieを削除すればログアウト処理に
+      logout_user(current_user)
+      flash[:success] = 'ログアウトしました'
+    end
+    redirect_to(root_path)
   end
 
   def home

--- a/app/views/layouts/_header.slim
+++ b/app/views/layouts/_header.slim
@@ -85,6 +85,7 @@ header
                                     class: 'dropdown-item'
                                 = link_to 'ログアウト',
                                     logout_path,
+                                    method: :post,
                                     class: 'dropdown-item'
 
                     - else

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -124,7 +124,7 @@ Rails.application.routes.draw do
   get '/updateuser', to: 'users#updateuser'
   get '/recommended_users', to: 'users#recommended_users'
   get '/login', to: 'users#new'
-  get '/logout', to: 'users#logout'
+  post '/logout', to: 'users#logout'
   get '/notifications', to: 'users#notifications'
   post '/notifications', to: 'users#notifications_checked'
   get '/omakase', to: 'notes#omakase'


### PR DESCRIPTION
- 二重にログアウト処理が走るとエラーになる問題を解消
- pre-fetch処理を防ぐため`GET /logout`を`POST /logout`に書き換え