### PR TITLE
一部ブラウザにおいてPATCH /notes/:idが正常にできない問題の修正

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -110,6 +110,9 @@ Rails.application.routes.draw do
     # get '/leave', to: 'users#leave'
   end
 
+  # Firefox等一部ブラウザにおいて、PATCHメソッドのフォームがPOSTになってしまう問題の解消用
+  post '/notes/:id', to: 'notes#update'
+
   # リソース:アナウンス
   resources :announces, only: %i[index create update show destroy]
 


### PR DESCRIPTION
Firefoxにおいて、ノートの「編集する」メニューを適用すると404になってしまう

原因:
Firefoxにおいて編集フォームのmethodが`post`になってしまい、`POST /notes/:id`が存在しないため404になる

修正方法:
formを色々いじってみても解決しなさそうなので`routes.rb`をいじって`POST /notes/:id`を許容するようにしました