### PR TITLE
Jenkinsの導入

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ erd.pdf
 
 # Ignore precompiled assets
 /public/assets
+
+# Ignore jenkins data
+/.jenkins

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -25,8 +25,18 @@ services:
       - "443:443"
     links:
       - app
+      - jenkins
     restart: always
     environment:
       DOMAINS: 'beta.shinchoku.net -> http://app:3000'
       # FORCE_RENEW: 'true' # テスト用。STAGE: productionの場合は切る
-      STAGE: 'production'
+      # STAGE: 'production'
+  jenkins:
+    image: jenkins/jenkins:lts
+    ports:
+      - "8080:8080"
+      - "50000:50000"
+    environment:
+      JENKINS_OPTS: '--prefix=/jenkins'
+    volumes:
+      - .jenkins:/var/jenkins_home

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -32,7 +32,9 @@ services:
       # FORCE_RENEW: 'true' # テスト用。STAGE: productionの場合は切る
       # STAGE: 'production'
   jenkins:
-    image: jenkins/jenkins:lts
+    build:
+      context: .
+      dockerfile: ./docker/jenkins/Dockerfile
     ports:
       - "8080:8080"
       - "50000:50000"
@@ -40,3 +42,4 @@ services:
       JENKINS_OPTS: '--prefix=/jenkins'
     volumes:
       - .jenkins:/var/jenkins_home
+      - /var/run/docker.sock:/var/run/docker.sock

--- a/docker/jenkins/Dockerfile
+++ b/docker/jenkins/Dockerfile
@@ -1,0 +1,17 @@
+FROM jenkins/jenkins:lts
+
+ENV DOCKER_VERSION 19.03.5
+ENV DOCKER_COMPOSE_VERSION 1.25.0
+
+USER root
+
+# docker, docker composeのインストール
+RUN curl -fL -o docker.tgz "https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}.tgz" && \
+    tar --strip-components=1 -xvzf docker.tgz -C /usr/bin
+RUN curl -o /usr/local/bin/docker-compose -L "https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m`" && \
+    chmod +x /usr/local/bin/docker-compose
+
+# dockerをsudoコマンドなしで使用可能に
+RUN echo "jenkins ALL=(root) NOPASSWD: /usr/bin/docker" >> /etc/sudoers
+
+USER jenkins

--- a/nginx/https_config.erb
+++ b/nginx/https_config.erb
@@ -32,4 +32,15 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
     }
+
+    # Rooting for jenkins
+    location /jenkins {
+        proxy_pass http://jenkins:8080;
+	proxy_redirect off;
+	proxy_set_header Host $host;
+	proxy_set_header X-Real-IP $remote_addr;
+	proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+	proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
 }


### PR DESCRIPTION
Jenkinsを使ってGUI上でワンタッチでデプロイ出来るようにする

### Jenkinsに任せること

- Githubリポジトリから`master`ブランチ(このPR完成までは`using_jenkins`ブランチ)をpullする
- `app`コンテナを再起動する

### Todo

- [ ] Jenkinsインストール
- [ ] Railsマスターキーなどのcredential情報の受け渡しが出来るように
- [ ] jobsをgithubで管理できるように