### PR TITLE
OkComputerのインストール

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,6 +74,9 @@ gem 'annotate', '~>2.7.4'
 # Google reCAPTCHA
 gem 'recaptcha', require: "recaptcha/rails"
 
+# ヘルスチェック用のエンドポイントを生やしてくれる
+gem 'okcomputer'
+
 # fixing security vulnerabilities
 gem 'sprockets', '~> 3.7.2'
 gem 'ffi', '~> 1.9.25'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -190,6 +190,7 @@ GEM
     nokogiri (1.10.7)
       mini_portile2 (~> 2.4.0)
     oauth (0.5.4)
+    okcomputer (1.18.1)
     omniauth (1.9.0)
       hashie (>= 3.4.6, < 3.7.0)
       rack (>= 1.6.2, < 3)
@@ -395,6 +396,7 @@ DEPENDENCIES
   mini_racer (~> 0.2.3)
   momentjs-rails (>= 2.9.0)
   newrelic_rpm
+  okcomputer
   omniauth (~> 1.9)
   omniauth-twitter (~> 1.4)
   paranoia (~> 2.4)

--- a/config/application.rb
+++ b/config/application.rb
@@ -13,6 +13,7 @@ module ShinchokuNote
 
     # Set locale to Japanese
     config.i18n.default_locale = :ja
+    config.i18n.fallbacks = [:ja, :en]
 
     # Setting for sqlite3 in test env
     Rails.application.config.active_record.sqlite3.represent_boolean_as_integer = false

--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -1,0 +1,1 @@
+OkComputer.mount_at = 'health'


### PR DESCRIPTION
##  概要(What)

ヘルスチェック用エンドポイントを生やしてくれるgem、OkComputerのインストール

https://github.com/sportngin/okcomputer

生えるエンドポイント:
- /health
- /health/database
- /health/all

## 理由(Why)

kubernetes化時、Readiness checkのためにヘルスチェック用エンドポイントが必要なため

## ついでの変更

- i18nのdefault fallbackの設定を変更（locale errorが出たため）