### PR TITLE
ヘルスチェック時にはforce_sslを無効化する

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -46,6 +46,12 @@ Rails.application.configure do
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = true
+  # Exclude force_ssl on health check
+  config.ssl_options = {
+    redirect: {
+      exclude: -> request { request.path =~ /\A\/health[\w\/]*\z/ }
+    }
+  }
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.


### PR DESCRIPTION
ヘルスチェックはKubernetesノード内部から直接Railsのpodに対して行うため、HTTPで叩く