### PR TITLE
spring gemの使用を停止

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -97,8 +97,9 @@ group :development, :test do
 end
 
 group :development do
-  gem 'spring', '~>2.0'
-  gem 'spring-watcher-listen', '~> 2.0.0'
+  # docker-composeを使う場合メリットが無さそうなのでspringを無効化
+  # gem 'spring', '~>2.0'
+  # gem 'spring-watcher-listen', '~> 2.0.0'
   gem 'web-console', '~>3.5'
 
   # code refactoring

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -314,11 +314,6 @@ GEM
     slim (3.0.9)
       temple (>= 0.7.6, < 0.9)
       tilt (>= 1.3.3, < 2.1)
-    spring (2.0.2)
-      activesupport (>= 4.2)
-    spring-watcher-listen (2.0.1)
-      listen (>= 2.7, < 4.0)
-      spring (>= 1.2, < 3.0)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -420,8 +415,6 @@ DEPENDENCIES
   serviceworker-rails
   simpacker
   slim (~> 3.0)
-  spring (~> 2.0)
-  spring-watcher-listen (~> 2.0.0)
   sprockets (~> 3.7.2)
   turbolinks (~> 5)
   turnout (~> 2.4)


### PR DESCRIPTION
(development環境にのみ影響)

Springはdev環境で複数回railsを起動する際、2回目以降の起動を高速化するgem
しかし現状devではdocker-composeを使用しているため、Springの恩恵を受けられていない
加えて、Springが入っているためにdocker-compose上でrails cやrails testが失敗することがある（Could not find gemみたいなのが出る）
よって使用を停止する