### PR TITLE
Noteの並び順を更新順になるように

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -111,6 +111,7 @@ end
 
 group :test do
   gem 'rails-controller-testing', '~>1.0'
+  gem 'timecop'
   gem "minitest-stub_any_instance"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -332,6 +332,7 @@ GEM
     thor (0.20.3)
     thread_safe (0.3.6)
     tilt (2.0.8)
+    timecop (0.9.1)
     turbolinks (5.1.1)
       turbolinks-source (~> 5.1)
     turbolinks-source (5.1.0)
@@ -425,6 +426,7 @@ DEPENDENCIES
   simpacker
   slim (~> 3.0)
   sprockets (~> 3.7.2)
+  timecop
   turbolinks (~> 5)
   turnout (~> 2.4)
   twitter (~> 6.2.0)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -30,7 +30,7 @@ class User < ApplicationRecord
   validates :twitter_id, uniqueness: true
   validates :screen_name, presence: true
 
-  has_many :notes,
+  has_many :notes, -> { order("updated_at desc") },
            dependent: :destroy
 
   has_many :comments,

--- a/app/views/users/_user.html.erb
+++ b/app/views/users/_user.html.erb
@@ -14,7 +14,7 @@
                 </div>
             </div>
             <div class="col-12 text-center text-lightgray">最近のノート</div>
-            <% user.notes.last(2).each do |n| %>
+            <% user.notes.limit(2).each do |n| %>
             <div class="col-12 col-sm-6">
                 <%= render n %>
             </div>

--- a/test/models/note_test.rb
+++ b/test/models/note_test.rb
@@ -50,4 +50,63 @@ class NoteTest < ActiveSupport::TestCase
       project.type = 'Undefined'
     end
   end
+
+  test '投稿すると更新日が更新される' do
+    today = Time.current
+    yesterday = today.yesterday
+
+    note = nil
+    Timecop.freeze(yesterday) do
+      note = create(:project)
+    end
+    assert_equal note.updated_at, yesterday
+
+    post = nil
+    Timecop.freeze(today) do
+      post = create(:post, note: note)
+    end
+    assert_equal note.updated_at, today
+  end
+
+  test 'user.noteが作成日降順に並ぶ' do
+    user = create(:user)
+    current_note = create(:project, user: user)
+    old_note, new_note = nil
+    Timecop.freeze(Time.current.yesterday) do
+      old_note = create(:project, user: user)
+    end
+    Timecop.freeze(Time.current.tomorrow) do
+      new_note = create(:project, user: user)
+    end
+
+    assert_equal user.notes.first.id, new_note.id
+    assert_equal user.notes.second.id, current_note.id
+    assert_equal user.notes.third.id, old_note.id
+  end
+
+  test 'user.noteが更新日降順に並ぶ' do
+    user = create(:user)
+    old_note, older_note = nil
+    Timecop.freeze(Time.current.yesterday) do
+      old_note = create(:project, user: user)
+    end
+    Timecop.freeze(Time.current.ago(2.days)) do
+      older_note = create(:project, user: user)
+    end
+
+    assert_equal user.notes.first.id, old_note.id
+    assert_equal user.notes.second.id, older_note.id
+
+    # 新規投稿をすると順番が入れ替わる
+
+    create(:post, note: older_note)
+
+    assert_equal user.notes.first.id, older_note.id
+    assert_equal user.notes.second.id, old_note.id
+
+    create(:post, note: old_note)
+
+    assert_equal user.notes.first.id, old_note.id
+    assert_equal user.notes.second.id, older_note.id
+  end
 end


### PR DESCRIPTION
Closes: #218 

Postのbelongs_to touch: trueはもうやってたので
テストを追加し、user.notesのデフォルトスコープの並び順を更新順にした。