### PR TITLE
Mock用gemのmochaを導入

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -112,7 +112,6 @@ end
 group :test do
   gem 'rails-controller-testing', '~>1.0'
   gem 'timecop'
-  gem "minitest-stub_any_instance"
   gem 'mocha'
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -113,6 +113,7 @@ group :test do
   gem 'rails-controller-testing', '~>1.0'
   gem 'timecop'
   gem "minitest-stub_any_instance"
+  gem 'mocha'
 end
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -188,6 +188,7 @@ GEM
       libv8 (>= 6.3)
     minitest (5.11.3)
     minitest-stub_any_instance (1.0.2)
+    mocha (1.11.2)
     momentjs-rails (2.20.1)
       railties (>= 3.1)
     multi_json (1.13.1)
@@ -403,6 +404,7 @@ DEPENDENCIES
   mini_magick (~> 4.8)
   mini_racer (~> 0.2.3)
   minitest-stub_any_instance
+  mocha
   momentjs-rails (>= 2.9.0)
   newrelic_rpm
   okcomputer

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -187,7 +187,6 @@ GEM
     mini_racer (0.2.3)
       libv8 (>= 6.3)
     minitest (5.11.3)
-    minitest-stub_any_instance (1.0.2)
     mocha (1.11.2)
     momentjs-rails (2.20.1)
       railties (>= 3.1)
@@ -403,7 +402,6 @@ DEPENDENCIES
   loofah (>= 2.2.3)
   mini_magick (~> 4.8)
   mini_racer (~> 0.2.3)
-  minitest-stub_any_instance
   mocha
   momentjs-rails (>= 2.9.0)
   newrelic_rpm

--- a/test/controllers/comments_controller_test.rb
+++ b/test/controllers/comments_controller_test.rb
@@ -6,12 +6,17 @@ class CommentsControllerTest < ActionDispatch::IntegrationTest
 
   def setup
     @okaka = create(:user)
-    @noritama = create(:user)  # Noritama follows okaka
-    @noriwasa = create(:user)  # Noriwasa doesn't follow okaka
+    @noritama = create(:user)
+    @noriwasa = create(:user)
     @okaka_project1 = create(:project, user: @okaka)
     @noritama_project1 = create(:project, user: @noritama)
     @okaka_comment1 = create(:comment, from_user: @okaka, to_note: @noritama_project1)
     @noritama_comment1 = create(:comment, from_user: @noritama, to_note: @okaka_project1)
+
+    # Noritama follows okaka
+    Twitter::REST::Client.any_instance.stubs(:friendship?).with(@noritama.screen_name, @okaka.screen_name).returns(true)
+    # Noriwasa doesn't follow okaka
+    Twitter::REST::Client.any_instance.stubs(:friendship?).with(@noriwasa.screen_name, @okaka.screen_name).returns(false)
   end
 
   test 'make new comment(everyone)' do
@@ -101,47 +106,39 @@ class CommentsControllerTest < ActionDispatch::IntegrationTest
     @okaka_project1.only_follower_comment_receive_stance!
     @okaka_project1.save!
 
-    client_mock = Minitest::Mock.new
-    client_mock.expect :friendship?, false, [@noriwasa.screen_name, @okaka.screen_name]
-    client_mock.expect :friendship?, true, [@noritama.screen_name, @okaka.screen_name]
+    # Comment from anonimous
+    assert_no_difference '@okaka_project1.comments.count' do
+      post note_comments_path(@okaka_project1), params: { comment: {
+        text: 'Comment of anonimous',
+        anonimity: :anonimity_secret
+      } }
+    end
 
-    CommentsController.stub_any_instance(:client_new, client_mock) do
-      NotesController.stub_any_instance(:client_new, client_mock) do
-        # Comment from anonimous
-        assert_no_difference '@okaka_project1.comments.count' do
-          post note_comments_path(@okaka_project1), params: { comment: {
-            text: 'Comment of anonimous',
-            anonimity: :anonimity_secret
-          } }
-        end
+    # Comment from other user (not follower)
+    login_for_test @noriwasa
+    assert_no_difference '@okaka_project1.comments.count' do
+      post note_comments_path(@okaka_project1), params: { comment: {
+        text: 'Comment of others',
+        anonimity: :anonimity_secret
+      } }
+    end
 
-        # Comment from other user (not follower)
-        login_for_test @noriwasa
-        assert_no_difference '@okaka_project1.comments.count' do
-          post note_comments_path(@okaka_project1), params: { comment: {
-            text: 'Comment of others',
-            anonimity: :anonimity_secret
-          } }
-        end
+    # Comment from other user (follower)
+    login_for_test @noritama
+    assert_difference '@okaka_project1.comments.count', 1 do
+      post note_comments_path(@okaka_project1), params: { comment: {
+        text: 'Comment of others',
+        anonimity: :anonimity_secret
+      } }
+    end
 
-        # Comment from other user (follower)
-        login_for_test @noritama
-        assert_difference '@okaka_project1.comments.count', 1 do
-          post note_comments_path(@okaka_project1), params: { comment: {
-            text: 'Comment of others',
-            anonimity: :anonimity_secret
-          } }
-        end
-
-        # Comment of myself
-        login_for_test @okaka
-        assert_difference '@okaka_project1.comments.count', 1 do
-          post note_comments_path(@okaka_project1), params: { comment: {
-            text: 'Comment of myself',
-            anonimity: :anonimity_secret
-          } }
-        end
-      end
+    # Comment of myself
+    login_for_test @okaka
+    assert_difference '@okaka_project1.comments.count', 1 do
+      post note_comments_path(@okaka_project1), params: { comment: {
+        text: 'Comment of myself',
+        anonimity: :anonimity_secret
+      } }
     end
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,7 +1,5 @@
 require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
-require 'minitest/autorun'
-require 'minitest/stub_any_instance'
 require 'mocha/minitest'
 
 module UserTestHelper

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,12 +6,11 @@ require 'mocha/minitest'
 
 module UserTestHelper
   def login_for_test(user, token = 'token', secret = 'secret')
-    verify_user_mock = Minitest::Mock.new.expect :call, true
-    self.stub(:verify_user_info, verify_user_mock) do
-      @current_user = nil
-      @master_user = nil
-      login_user user, token, secret
-    end
+    self.expects(:verify_user_info).returns(true)
+
+    @current_user = nil
+    @master_user = nil
+    login_user user, token, secret
   end
 end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,6 +2,7 @@ require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
 require 'minitest/autorun'
 require 'minitest/stub_any_instance'
+require 'mocha/minitest'
 
 module UserTestHelper
   def login_for_test(user, token = 'token', secret = 'secret')


### PR DESCRIPTION
Minitest標準gemが使いづらいので、RSpecに近い書き方ができるmochaを導入

同時に不要になったminitest-stub_any_instanceを削除