### PR TITLE
watching_postsから権限的に見られないpostを削除

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -125,17 +125,22 @@ class PostsController < ApplicationController
     # note_idがwatching_noteであるpostを抽出
     allowed_types = %w[TweetPost PlainPost]
 
+    posts = []
     if from_post.nil?
-      Post.where('type IN (?)', allowed_types)
+      posts = Post.where('type IN (?)', allowed_types)
           .where('note_id IN (?)', current_user.watching_notes.map(&:id))
           .order('created_at DESC')
           .limit(size)
     else
-      Post.where('type IN (?)', allowed_types)
+      posts = Post.where('type IN (?)', allowed_types)
           .where('note_id IN (?)', current_user.watching_notes.map(&:id))
           .where('created_at < (?)', from_post.created_at)
           .order('created_at DESC')
           .limit(size)
+    end
+
+    posts.select do |p|
+      user_can_see? p.note, current_user
     end
   end
 end


### PR DESCRIPTION
「ウォッチリストに登録されたノートを後から権限変更してもタイムラインから消えない」という報告を受け対処
ウォッチリストに登録されているものも権限をチェックし、見られるものだけをフィルターするように