### PR TITLE
コメント投稿時に500エラーになる問題の修正

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -44,6 +44,7 @@ class CommentsController < ApplicationController
     @comment = @note.comments.new(comments_params)
 
     unless user_can_comment?(@note, current_user)
+      load_comments
       flash.now[:danger] = 'ノートの設定でコメントが投稿できませんでした。ノートの所有者にお問い合わせください。'
       render 'notes/show'
       return
@@ -81,6 +82,7 @@ class CommentsController < ApplicationController
       redirect_to note_path(@note)
     else
       # やりなおし
+      load_comments
       flash.now[:danger] = 'コメントの投稿に失敗しました。'
       render 'notes/show'
     end

--- a/test/factories/notes.rb
+++ b/test/factories/notes.rb
@@ -31,7 +31,7 @@ FactoryBot.define do
     desc { Faker::Lorem.paragraph }
     view_stance { :everyone }
     comment_receive_stance { :everyone }
-    comment_share_stance { :only_me }
+    comment_share_stance { :everyone }
 
     association :user
 


### PR DESCRIPTION
ノートの設定で投稿できない場合など、`Comment#create`で`render 'notes/show'`が呼び出される際、`@comments`がロードされていないためにエラーが発生していたため、明示的に`load_comments`を呼ぶことで解消