### PR TITLE
コメントAPIへのreCAPTCHAの導入

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -124,6 +124,7 @@ group :test do
   gem 'rails-controller-testing', '~>1.0'
   gem 'timecop'
   gem 'mocha'
+  gem 'webmock'
 end
 
 group :production do

--- a/Gemfile
+++ b/Gemfile
@@ -86,6 +86,9 @@ gem 'active_model_serializers'
 # pagination用gem kaminari
 gem 'kaminari'
 
+# HTTPクライアント Faraday
+gem 'faraday'
+
 # fixing security vulnerabilities
 gem 'sprockets', '~> 3.7.2'
 gem 'ffi', '~> 1.9.25'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,7 +117,7 @@ GEM
       railties (>= 5.0.0)
     faker (2.2.1)
       i18n (>= 0.8)
-    faraday (0.15.2)
+    faraday (0.17.3)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.25)
     font-awesome-rails (4.7.0.4)
@@ -221,7 +221,7 @@ GEM
     momentjs-rails (2.20.1)
       railties (>= 3.1)
     multi_json (1.13.1)
-    multipart-post (2.0.0)
+    multipart-post (2.1.1)
     naught (1.1.0)
     newrelic_rpm (5.1.0.344)
     nio4r (2.3.1)
@@ -426,6 +426,7 @@ DEPENDENCIES
   enum_help (~> 0.0)
   factory_bot_rails
   faker
+  faraday
   ffi (~> 1.9.25)
   font-awesome-rails (~> 4.7)
   google-cloud-storage (~> 1.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,6 +99,8 @@ GEM
       committee (>= 3.0.0)
       railties
     concurrent-ruby (1.1.4)
+    crack (0.4.5)
+      rexml
     crass (1.0.5)
     declarative (0.0.10)
     declarative-option (0.1.0)
@@ -148,6 +150,7 @@ GEM
       multi_json (~> 1.11)
       os (~> 0.9)
       signet (~> 0.7)
+    hashdiff (1.0.1)
     hashie (3.6.0)
     hkdf (0.3.0)
     http (3.3.0)
@@ -302,6 +305,7 @@ GEM
       declarative-option (< 0.2.0)
       uber (< 0.2.0)
     retriable (3.1.2)
+    rexml (3.2.4)
     rubocop (0.55.0)
       parallel (~> 1.10)
       parser (>= 2.5)
@@ -397,6 +401,10 @@ GEM
       activemodel (>= 5.0)
       bindex (>= 0.4.0)
       railties (>= 5.0)
+    webmock (3.11.2)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     webpush (0.3.4)
       hkdf (~> 0.2)
       jwt (~> 2.0)
@@ -468,6 +476,7 @@ DEPENDENCIES
   twitter (~> 6.2.0)
   uglifier (>= 1.3.0)
   web-console (~> 3.5)
+  webmock
   webpush
   whenever (~> 0.10.0)
   will_paginate (~> 3.1.5)

--- a/app/controllers/api/v1/comments_controller.rb
+++ b/app/controllers/api/v1/comments_controller.rb
@@ -65,6 +65,21 @@ module Api
           return
         end
 
+        # reCAPTCHA認証処理
+        conn = Faraday.new(url: 'https://www.google.com')
+        response = conn.post '/recaptcha/api/siteverify', {
+          secret: Rails.application.credentials.recaptcha[:secret],
+          response: params[:recaptcha]
+        }
+        response_hash = JSON.parse response.body
+        unless response_hash['success']
+          render json: {
+            code: 'recaptcha_failed',
+            message: 'reCAPTCHAによる認証に失敗しました。'
+          }, status: :bad_request
+          return
+        end
+
         @comment = @note.comments.new(comments_params)
 
         # 投稿者情報の埋め込み

--- a/app/controllers/api/v1/comments_controller.rb
+++ b/app/controllers/api/v1/comments_controller.rb
@@ -66,10 +66,12 @@ module Api
         end
 
         # reCAPTCHA認証処理
+        recaptcha_token = recaptcha_params[:token]
+        recaptcha_secret = recaptcha_params[:using_checkbox] ? Rails.application.credentials.recaptcha_v2[:secret] : Rails.application.credentials.recaptcha[:secret]
         conn = Faraday.new(url: 'https://www.google.com')
         response = conn.post '/recaptcha/api/siteverify', {
-          secret: Rails.application.credentials.recaptcha[:secret],
-          response: params[:recaptcha]
+          secret: recaptcha_secret,
+          response: recaptcha_token
         }
         response_hash = JSON.parse response.body
         unless response_hash['success']
@@ -112,6 +114,10 @@ module Api
 
       def comments_params
         params.require(:comment).permit(:text, :anonimity)
+      end
+
+      def recaptcha_params
+        params.require(:recaptcha).permit(:token, :using_checkbox)
       end
     end
   end

--- a/app/javascript/components/modules/comments/comment_form.vue
+++ b/app/javascript/components/modules/comments/comment_form.vue
@@ -65,8 +65,10 @@ export default {
       }))
     },
     showSnackbar(message) {
+      // 連続してメッセージを表示する場合を考え、一度非表示にして再度表示する
+      this.snackbarEnabled = false
       this.snackbarText = message
-      this.snackbarEnabled = true
+      this.$nextTick(() => { this.snackbarEnabled = true })
     },
     onSubmit() {
       this.recaptchaV3.execute('social').then(token => {

--- a/app/javascript/components/modules/comments/comment_form.vue
+++ b/app/javascript/components/modules/comments/comment_form.vue
@@ -12,26 +12,38 @@
       v-btn(@click="postComment" rounded color="primary" :disabled="text.length == 0").follow-btn.font-weight-bold コメントする
 
       v-snackbar(v-model="snackbarEnabled" timeout=3000) {{snackbarText}}
+    vue-recaptcha(v-if="recaptchaV2Enabled" :sitekey="recaptchaKeyV2")
 </template>
 
 <script>
+import VueRecaptcha from 'vue-recaptcha'
 import { load } from 'recaptcha-v3'
 
-const recaptchaKey = '6Lf4JqgUAAAAANnrDZwns_XB_Sw0Vm3KdSKROLZk'
+const recaptchaKeyV2 = '6LejIbEUAAAAADO263cfRghHFoAvL_SuykU5tfV2'
+const recaptchaKeyV3 = '6Lf4JqgUAAAAANnrDZwns_XB_Sw0Vm3KdSKROLZk'
 
 export default {
   name: 'comment-form',
+  components: {
+    VueRecaptcha
+  },
   data: () => {
     return {
       text: '',
       showAuthor: false,
       snackbarEnabled: false,
       snackbarText: '',
-      recaptcha: null
+      recaptchaV3: null,
+      recaptchaV2Enabled: false
     };
   },
   async created() {
-    this.recaptcha = await load(recaptchaKey)
+    // reCAPTCHA v2のスクリプトをロード
+    const recaptchaV2Script = document.createElement('script')
+    recaptchaV2Script.setAttribute('src', 'https://www.google.com/recaptcha/api.js?onload=vueRecaptchaApiLoaded&render=explicit');
+    document.body.appendChild(recaptchaV2Script);
+
+    this.recaptchaV3 = await load(recaptchaKeyV3)
   },
   computed: {
     anonimity() {
@@ -42,11 +54,12 @@ export default {
         text: this.text,
         anonimity: this.anonimity
       }
-    }
+    },
+    recaptchaKeyV2: () => recaptchaKeyV2
   },
   methods: {
     postComment() {
-      this.recaptcha.execute('social').then(token => {
+      this.recaptchaV3.execute('social').then(token => {
         this.axios.post(`/api/v1/notes/${ this.$route.params.id }/comments`, {
           comment: this.newComment,
           recaptcha: token
@@ -57,7 +70,14 @@ export default {
           this.showAuthor = false
         })
         .catch((error) => {
-          this.showSnackbar(error.response.data.message)
+          switch(error.response.data.code) {
+            case 'recaptcha_failed':
+              this.showSnackbar('「私はロボットではありません」をチェックして下さい。')
+              this.recaptchaV2Enabled = true
+              break
+            default:
+              this.showSnackbar(error.response.data.message)
+          }
         })
         .then(() => {
           // always executed

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "mini-css-extract-plugin": "^0.9.0",
     "pug": "^2.0.4",
     "pug-plain-loader": "^1.0.0",
+    "recaptcha-v3": "^1.8.0",
     "sass": "^1.26.5",
     "sass-loader": "^8.0.2",
     "svg-inline-loader": "^0.8.2",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "vue-axios": "^2.1.5",
     "vue-easy-lightbox": "^0.13.0",
     "vue-loader": "^15.9.2",
+    "vue-recaptcha": "^1.3.0",
     "vue-router": "^3.1.6",
     "vue-template-compiler": "^2.6.11",
     "vuetify": "^2.3.1",

--- a/test/controllers/api/v1/comments_controller_test.rb
+++ b/test/controllers/api/v1/comments_controller_test.rb
@@ -18,6 +18,15 @@ module Api
         Twitter::REST::Client.any_instance.stubs(:friendship?)
                              .with(@not_follower.screen_name, @user.screen_name)
                              .returns(false)
+
+        # reCAPTCHA stub
+        # Rails 6にバージョンアップしたら、reCAPTCHAのダミートークンが使えるかも
+        # (参考: https://developers.google.com/recaptcha/docs/faq#id-like-to-run-automated-tests-with-recaptcha.-what-should-i-do)
+        stub_request(:post, "https://www.google.com/recaptcha/api/siteverify").to_return(
+          status: 200,
+          body: { success: true }.to_json,
+          headers: {}
+        )
       end
 
       # GET /notes/{id}/comments
@@ -269,7 +278,7 @@ module Api
       # POST /notes/{id}/comments
 
       test 'POST /notes/{id}/comments 正常なリクエスト' do
-        post api_v1_note_comments_path(@project), params: { comment: { text: 'Comment!' } }
+        post api_v1_note_comments_path(@project), params: { comment: { text: 'Comment!' }, recaptcha: { token: 'recaptcha_token', using_checkbox: true } }
         assert_response :created
         assert_request_schema_confirm
       end
@@ -277,7 +286,7 @@ module Api
       test 'POST /notes/{id}/comments 存在しないnoteへのリクエスト' do
         @project.destroy!
 
-        post api_v1_note_comments_path(@project), params: { comment: { text: 'Comment!' } }
+        post api_v1_note_comments_path(@project), params: { comment: { text: 'Comment!' }, recaptcha: { token: 'recaptcha_token', using_checkbox: true } }
         assert_response :not_found
       end
 
@@ -287,28 +296,28 @@ module Api
 
         # 未ログインユーザー
         assert_difference '@project.comments.count', 1 do
-          post api_v1_note_comments_path(@project), params: { comment: { text: 'Comment!' } }
+          post api_v1_note_comments_path(@project), params: { comment: { text: 'Comment!' }, recaptcha: { token: 'recaptcha_token', using_checkbox: true } }
           assert_response :created
         end
 
         # not follower
         login_for_test @not_follower
         assert_difference '@project.comments.count', 1 do
-          post api_v1_note_comments_path(@project), params: { comment: { text: 'Comment!' } }
+          post api_v1_note_comments_path(@project), params: { comment: { text: 'Comment!' }, recaptcha: { token: 'recaptcha_token', using_checkbox: true } }
           assert_response :created
         end
 
         # follower
         login_for_test @follower
         assert_difference '@project.comments.count', 1 do
-          post api_v1_note_comments_path(@project), params: { comment: { text: 'Comment!' } }
+          post api_v1_note_comments_path(@project), params: { comment: { text: 'Comment!' }, recaptcha: { token: 'recaptcha_token', using_checkbox: true } }
           assert_response :created
         end
 
         # 作成者
         login_for_test @user
         assert_difference '@project.comments.count', 1 do
-          post api_v1_note_comments_path(@project), params: { comment: { text: 'Comment!' } }
+          post api_v1_note_comments_path(@project), params: { comment: { text: 'Comment!' }, recaptcha: { token: 'recaptcha_token', using_checkbox: true } }
           assert_response :created
         end
       end
@@ -319,28 +328,28 @@ module Api
 
         # 未ログインユーザー
         assert_no_difference '@project.comments.count' do
-          post api_v1_note_comments_path(@project), params: { comment: { text: 'Comment!' } }
+          post api_v1_note_comments_path(@project), params: { comment: { text: 'Comment!' }, recaptcha: { token: 'recaptcha_token', using_checkbox: true } }
           assert_response :forbidden
         end
 
         # not follower
         login_for_test @not_follower
         assert_difference '@project.comments.count', 1 do
-          post api_v1_note_comments_path(@project), params: { comment: { text: 'Comment!' } }
+          post api_v1_note_comments_path(@project), params: { comment: { text: 'Comment!' }, recaptcha: { token: 'recaptcha_token', using_checkbox: true } }
           assert_response :created
         end
 
         # follower
         login_for_test @follower
         assert_difference '@project.comments.count', 1 do
-          post api_v1_note_comments_path(@project), params: { comment: { text: 'Comment!' } }
+          post api_v1_note_comments_path(@project), params: { comment: { text: 'Comment!' }, recaptcha: { token: 'recaptcha_token', using_checkbox: true } }
           assert_response :created
         end
 
         # 作成者
         login_for_test @user
         assert_difference '@project.comments.count', 1 do
-          post api_v1_note_comments_path(@project), params: { comment: { text: 'Comment!' } }
+          post api_v1_note_comments_path(@project), params: { comment: { text: 'Comment!' }, recaptcha: { token: 'recaptcha_token', using_checkbox: true } }
           assert_response :created
         end
       end
@@ -351,28 +360,28 @@ module Api
 
         # 未ログインユーザー
         assert_no_difference '@project.comments.count' do
-          post api_v1_note_comments_path(@project), params: { comment: { text: 'Comment!' } }
+          post api_v1_note_comments_path(@project), params: { comment: { text: 'Comment!' }, recaptcha: { token: 'recaptcha_token', using_checkbox: true } }
           assert_response :forbidden
         end
 
         # not follower
         login_for_test @not_follower
         assert_no_difference '@project.comments.count' do
-          post api_v1_note_comments_path(@project), params: { comment: { text: 'Comment!' } }
+          post api_v1_note_comments_path(@project), params: { comment: { text: 'Comment!' }, recaptcha: { token: 'recaptcha_token', using_checkbox: true } }
           assert_response :forbidden
         end
 
         # follower
         login_for_test @follower
         assert_difference '@project.comments.count', 1 do
-          post api_v1_note_comments_path(@project), params: { comment: { text: 'Comment!' } }
+          post api_v1_note_comments_path(@project), params: { comment: { text: 'Comment!' }, recaptcha: { token: 'recaptcha_token', using_checkbox: true } }
           assert_response :created
         end
 
         # 作成者
         login_for_test @user
         assert_difference '@project.comments.count', 1 do
-          post api_v1_note_comments_path(@project), params: { comment: { text: 'Comment!' } }
+          post api_v1_note_comments_path(@project), params: { comment: { text: 'Comment!' }, recaptcha: { token: 'recaptcha_token', using_checkbox: true } }
           assert_response :created
         end
       end
@@ -383,28 +392,28 @@ module Api
 
         # 未ログインユーザー
         assert_no_difference '@project.comments.count' do
-          post api_v1_note_comments_path(@project), params: { comment: { text: 'Comment!' } }
+          post api_v1_note_comments_path(@project), params: { comment: { text: 'Comment!' }, recaptcha: { token: 'recaptcha_token', using_checkbox: true } }
           assert_response :forbidden
         end
 
         # not follower
         login_for_test @not_follower
         assert_no_difference '@project.comments.count' do
-          post api_v1_note_comments_path(@project), params: { comment: { text: 'Comment!' } }
+          post api_v1_note_comments_path(@project), params: { comment: { text: 'Comment!' }, recaptcha: { token: 'recaptcha_token', using_checkbox: true } }
           assert_response :forbidden
         end
 
         # follower
         login_for_test @follower
         assert_no_difference '@project.comments.count' do
-          post api_v1_note_comments_path(@project), params: { comment: { text: 'Comment!' } }
+          post api_v1_note_comments_path(@project), params: { comment: { text: 'Comment!' }, recaptcha: { token: 'recaptcha_token', using_checkbox: true } }
           assert_response :forbidden
         end
 
         # 作成者
         login_for_test @user
         assert_difference '@project.comments.count', 1 do
-          post api_v1_note_comments_path(@project), params: { comment: { text: 'Comment!' } }
+          post api_v1_note_comments_path(@project), params: { comment: { text: 'Comment!' }, recaptcha: { token: 'recaptcha_token', using_checkbox: true } }
           assert_response :created
         end
       end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,7 @@
 require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
 require 'mocha/minitest'
+require 'webmock/minitest'
 
 module UserTestHelper
   def login_for_test(user, token = 'token', secret = 'secret')

--- a/yarn.lock
+++ b/yarn.lock
@@ -4571,6 +4571,11 @@ vue-loader@^15.9.2:
     vue-hot-reload-api "^2.3.0"
     vue-style-loader "^4.1.0"
 
+vue-recaptcha@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/vue-recaptcha/-/vue-recaptcha-1.3.0.tgz#e668e54f798c6333057ef38b4425a72f451ce478"
+  integrity sha512-9Qf1niyHq4QbEUhsvdUkS8BoOyhYwpp8v+imUSj67ffDo9RQ6h8Ekq8EGnw/GKViXCwWalp7EEY/n/fOtU0FyA==
+
 vue-router@^3.1.6:
   version "3.1.6"
   resolved "https://registry.yarnpkg.com/vue-router/-/vue-router-3.1.6.tgz#45f5a3a3843e31702c061dd829393554e4328f89"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3565,6 +3565,11 @@ readdirp@~3.4.0:
   dependencies:
     picomatch "^2.2.1"
 
+recaptcha-v3@^1.8.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/recaptcha-v3/-/recaptcha-v3-1.8.0.tgz#b39ae7cba5322ed7027359c3f14502e44e909f83"
+  integrity sha512-ugtg4JHDZiYJwv3ZjWBBZntsTCVpRk2BD8AhVVpSw9jv71SSx+SS9H342VaE0D2XV78DpRdDuiMO9ZIgl4zI3A==
+
 regenerator-runtime@^0.11.0:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"


### PR DESCRIPTION
コメントAPIにもreCAPTCHAを導入する。
今回はreCAPTCHA gemは使えないので（Railsがフロントじゃないから）、バックエンド認証処理はFaradayで行う。

- Faradayのインストール
- フロントエンドreCAPTCHA v3実装
- フロントエンドが失敗した際のreCAPTCHA v2(checkbox)実装
- バックエンドreCAPTCHA実装