### PR TITLE
dockerコンテナ内のrailsコードの更新がリアルタイムで反映されるように

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -48,9 +48,8 @@ Rails.application.configure do
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 
-  # Use an evented file watcher to asynchronously detect changes in source code,
-  # routes, locales, etc. This feature depends on the listen gem.
-  config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+  # docker内で動作しないため、EventedFileUpdateCheckerは使わない
+  config.file_watcher = ActiveSupport::FileUpdateChecker
 
   # Encrypted_Secretsを使用する
   config.read_encrypted_secrets = true


### PR DESCRIPTION
dockerとFileWatcherの仕様により、ファイルを更新してもRailsのキャッシュのせいで反映されない状態となっていた。
FileWatcherをActiveSupport::FileUpdateCheckerにすることで、更新が反映されるようになった。

参考: https://railsguides.jp/configuring.html#rails%E5%85%A8%E8%88%AC%E3%81%AE%E8%A8%AD%E5%AE%9A